### PR TITLE
Change baseURL to call HTTPS rather than HTTP

### DIFF
--- a/src/FlightRadar24.php
+++ b/src/FlightRadar24.php
@@ -21,7 +21,7 @@ namespace Jawish\FlightRadar24;
  */
 class FlightRadar24
 {
-    public static $apiBaseUrl = 'http://www.flightradar24.com';
+    public static $apiBaseUrl = 'https://www.flightradar24.com';
 
     const PATH_LOAD_BALANCER = '/balance.json';
     const PATH_AIRPORTS = '/_json/airports.php';
@@ -485,7 +485,15 @@ class FlightRadar24
     protected function api($url)
     {
         try {
-            $json = json_decode(file_get_contents($url), true);
+            // Ignores SSL errors that will appear
+            $arrContextOptions=array(
+                "ssl"=>array(
+                    "verify_peer"=>false,
+                    "verify_peer_name"=>false,
+                ),
+            );  
+        
+            $json = json_decode(file_get_contents($url,false,stream_context_create($arrContextOptions)), true); 
         }
         catch (\Exception $e) {
             throw new \Exception(sprintf('An error occurred accessing API at %s.', $url));


### PR DESCRIPTION
It appears that FR24 have updated their system to allow only SSL enabled end points. This change updates $apiBaseUrl to use https rather than http and now ignores SSL errors in the file_get_contents call